### PR TITLE
Added the -betapassword argument

### DIFF
--- a/setup_resonite.sh
+++ b/setup_resonite.sh
@@ -4,7 +4,7 @@ bash "${STEAMCMDDIR}/steamcmd.sh" \
     +force_install_dir ${STEAMAPPDIR} \
     +login ${STEAMLOGIN} \
     +app_license_request ${STEAMAPPID} \
-    +app_update ${STEAMAPPID} -beta ${STEAMBETA} validate \
+    +app_update ${STEAMAPPID} -beta ${STEAMBETA} -betapassword ${STEAMBETAPASSWORD} validate \
     +quit
 
 if [ "$CLEANASSETS" = true ]; then


### PR DESCRIPTION
The container wasn't actually pulling the headless build, hence failing to start since the .../Headless/ directory didn't exist.